### PR TITLE
Fix null deprecation warning

### DIFF
--- a/inc/App/Histograms.php
+++ b/inc/App/Histograms.php
@@ -38,6 +38,9 @@ class Histograms {
 		global $wpdb;
 		$query = "select UPDATE_TIME from information_schema.tables where table_schema='mysql' and table_name='table_stats';";
 		$result = $wpdb->get_var($query);
+		if (is_null($result)) {
+			$result = 0;
+		}
 		return $result;
 	}
 


### PR DESCRIPTION
Last update check on the `table_stats` table can be NULL which causes a derecated call to the `DateTime` constructor. Return `0` in this case instead.

Fixes #4