### PR TITLE
Fix version check for < 10.2

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -72,7 +72,7 @@ function printr( $obj, $title = '' ) {
 function getFullDatabaseVersion() {
 	global $wpdb;
 
-	return $wpdb->get_var( "SELECT VERSION();" );
+	return $wpdb->get_var( "SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE VARIABLE_NAME = 'VERSION';" );
 }
 
 /**

--- a/templates/admin/main-general.php
+++ b/templates/admin/main-general.php
@@ -70,7 +70,7 @@ if ('general' === $active_stab) {
 				/* translators: Server version number */
 				_e( 'MariaDB version', 'mariadb-health-checks' );
 			?></td>
-			<td><?php echo esc_html($mdbhc_gd['version']); if( isset( $mdbhc_gd['version_comment'] ) ) { echo esc_html($mdbhc_gd['version_comment']);  } ?></td>
+			<td><?php echo esc_html($mdbhc_gd['version']);?> <?php if( isset( $mdbhc_gd['version_comment'] ) ) { echo esc_html($mdbhc_gd['version_comment']);  } ?></td>
 		</tr>
 	<?php
 	}


### PR DESCRIPTION
Older versions of MariaDB fake a version number for compatibility with older MySQL versions. This patch uses the real version number instead.