### PR TITLE
Use SAVEQUERIES if set

### DIFF
--- a/inc/App/ExecutionTime.php
+++ b/inc/App/ExecutionTime.php
@@ -11,16 +11,30 @@ class ExecutionTime {
 	public static function save_average_query_execution_time() {
 		global $wpdb;
 
-		if( !empty( $wpdb->total_query_time ) && !empty( $wpdb->num_queries ) && $wpdb->num_queries > 0 ) {
-
-			$wpdb->insert(
-				$wpdb->prefix . self::TABLE_NAME,
-				[
-					'seconds'     => $wpdb->total_query_time,
-					'queries_num' => $wpdb->num_queries
-				]
-			);
-
+		if ( defined( 'SAVEQUERIES' ) && SAVEQUERIES ) {
+			if ( !empty($wpdb->queries) && !empty($wpdb->num_queries) && $wpdb->num_queries > 0) {
+				$query_times = array();
+				foreach ( $wpdb->queries as $key => $value ) {
+					$query_times[] = $value[1];
+				}
+				$wpdb->insert(
+					$wpdb->prefix . self::TABLE_NAME,
+					[
+						'seconds'     => array_sum($query_times),
+						'queries_num' => $wpdb->num_queries
+					]
+				);
+			}
+		} else {
+			if( !empty( $wpdb->total_query_time ) && !empty( $wpdb->num_queries ) && $wpdb->num_queries > 0 ) {
+				$wpdb->insert(
+					$wpdb->prefix . self::TABLE_NAME,
+					[
+						'seconds'     => $wpdb->total_query_time,
+						'queries_num' => $wpdb->num_queries
+					]
+				);
+			}
 		}
 	}
 

--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -37,9 +37,12 @@ class MDB_DB extends wpdb
 	}
 }
 
-$tmp = new MDB_DB(DB_USER, DB_PASSWORD, DB_NAME, DB_HOST);
-$tmp->loadFromParentObj($wpdb);
-$wpdb = $tmp;
+// If savequeries is set, let's not duplicate effort
+if ( !defined( 'SAVEQUERIES' ) || !SAVEQUERIES ) {
+	$tmp = new MDB_DB(DB_USER, DB_PASSWORD, DB_NAME, DB_HOST);
+	$tmp->loadFromParentObj($wpdb);
+	$wpdb = $tmp;
+}
 
 function mdbhc_save_average_query_execution_time()
 {

--- a/readme.txt
+++ b/readme.txt
@@ -45,6 +45,7 @@ Extract the contents of the ZIP and upload the contents to the `/wp-content/plug
 * Add more useful metrics to the graph
 * Fix version check for MariaDB < 10.2
 * Drop plugin's tables on uninstall
+* Use SAVEQUERIES data if exists
 
 = 1.0.3 =
 


### PR DESCRIPTION
If SAVEQUERIES has been enabled on the server, use that data instead of generating our own and potentially breaking SAVEQUERIES.

Fixes #33 